### PR TITLE
WS-300: Fix unit test by cleaning up data at the end of the test

### DIFF
--- a/exo.ws.rest.ext/src/test/java/org/exoplatform/services/rest/ext/groovy/DefaultGroovyResourceLoaderTest.java
+++ b/exo.ws.rest.ext/src/test/java/org/exoplatform/services/rest/ext/groovy/DefaultGroovyResourceLoaderTest.java
@@ -47,6 +47,8 @@ public class DefaultGroovyResourceLoaderTest extends BaseTest
       assertNull(url);
       File f = new File(new URL(root, "MyClass.groovy").toURI());
       f.createNewFile();
+      // Clean up data so that Unit Test can be executed several time
+      f.deleteOnExit();
       url = groovyResourceLoader.loadGroovySource("MyClass");
       assertNotNull(url);
    }


### PR DESCRIPTION
Use `f.deleteOnExit();` so that the file created during the unit test is deleted when the JVM exit.

This fix is related to the Sonar job that fails because the test is executing twice without maven clean up before the second time the test is executed:
* https://ci.exoplatform.org/job/PLF/view/sonar/job/ws-develop-sonar/50/console